### PR TITLE
Add AddonSDK link

### DIFF
--- a/index.html
+++ b/index.html
@@ -59,7 +59,7 @@
       <li target="http://github.com/mozilla/shumway">Shumway
         <div class="extra">a Flash player written entirely in Javascript</div>
       </li>
-      <li>The addon SDK
+      <li target="https://wiki.mozilla.org/Jetpack">The addon SDK
         <div class="extra">the foundation upon which all new kick-ass addons are built</div>
       </li>
       <li target="https://wiki.mozilla.org/Gaia">Gaia


### PR DESCRIPTION
The Addon SDK didn't have a link to it's wiki page
