### PR TITLE
Windows 8 sections

### DIFF
--- a/index.html
+++ b/index.html
@@ -47,6 +47,9 @@
       <li target="https://wiki.mozilla.org/SVG:Contribute">SVG Project
         <div class="extra">help with the implementation and testing of Mozilla's <a href="https://developer.mozilla.org/en-US/docs/SVG">Scalable Vector Graphics</a> engine</div>
       </li>
+      <li target="https://wiki.mozilla.org/Firefox/Windows_8_Integration#Platform_Integration_Windows_8_Development">
+        <div class="extra">the Metro Style Enabled Desktop Browser for Windows 8</div>
+      </li>
     </ul>
   </div>
 
@@ -96,6 +99,9 @@
       </li>
       <li target="http://www.benmoskowitz.com/?p=527">Popcorn
         <div class="extra">create interactive media pages that seamlessly integrate video, audio, and traditional web technologies</div>
+      </li>
+      <li target="https://wiki.mozilla.org/Firefox/Windows_8_Integration#Front_End_Windows_8_Development">
+        <div class="extra">the front end for the Metro Style Enabled Desktop Browser for Windows 8</div>
       </li>
     </ul>
   </div>


### PR DESCRIPTION
Updated Firefox Windows 8 wiki with 2 sections for getting involved.
Front end (which doesn't require Windows 8) + Platform integration (which does require Windows 8)
