### PR TITLE
Fix texts in unknown languages browsers

### DIFF
--- a/foopy.js
+++ b/foopy.js
@@ -66,10 +66,32 @@ function takeBack() {
     switchGroup(stack[stack.length - 1]);
 }
 
+function langChange() {
+    document.webL10n.setLanguage(this.value);
+}
+
 $(window).load(function() {
     $('#ok')[0].onclick = investigate;
     $('#next')[0].onclick = nextChoice;
     $('#back')[0].onclick = takeBack;
+    $('#lang select')[0].onchange = langChange;
+
+
+    // Detected browser language
+    var browserLang = document.webL10n.getLanguage();
+    // Default language (value of the selected <option> element)
+    var defaultLang = $("#lang option:selected").val();
+
+    if (defaultLang !== browserLang) {
+        var option = $('#lang option[value=' + browserLang + ']');
+        if (option.length) {
+            // If the browser language is supported, select the good option
+            option.attr('selected', 'selected');
+        } else {
+            // Else set the default language
+            document.webL10n.setLanguage(defaultLang);
+        }
+    }
 
     switchGroup('proglang');
 });

--- a/index.html
+++ b/index.html
@@ -14,9 +14,9 @@
   <a href="http://www.mozilla.org/" id="tabzilla">mozilla</a>
   <div id="lang">
     <span data-l10n-id="lang-selection">language: </span>
-    <select onchange="document.webL10n.setLanguage(this.value || this.options[this.selectedIndex].text);">
-      <option selected>en</option>
-      <option>gr</option>
+    <select>
+      <option selected value='en'>en</option>
+      <option value='gr'>gr</option>
     </select>
   </div>
   


### PR DESCRIPTION
If the browser language is not in locales.ini, all texts are missing. It should display english texts instead.
