### PR TITLE
Removal of "rust-extra" string translation

### DIFF
--- a/locales.ini
+++ b/locales.ini
@@ -1,6 +1,5 @@
 ﻿[en]
 question = What's your favourite programming language?
-rust-extra = the new systems programming language created by Mozilla.
 cpp-intro = So you like long compile times and incomprehensible error messages? That's cool, we do too. You could work on
 cpp-gecko-extra = the engine that drives Firefox
 cpp-b2g-extra = the operating system for Android phones built on web technologies
@@ -67,7 +66,6 @@ negative6 = Keep going
 
 [ar]
 question = ما هي لغة البرمجة المفضلة لديك؟
-rust-extra = النظم الجديدة على لغة البرمجة التي أنشأتها موزيلا.
 cpp-intro = تريد تجميع طويلة مرات، ورسائل خطأ غير مفهومة؟ هذا هو بارد، ونحن نفعل أيضا. هل يمكن أن تعمل على بهذا
 cpp-gecko-extra = المحرك الذي يدفع فايرفوكس
 cpp-b2g-extra = نظام التشغيل للهواتف أندرويد مبنية على تقنيات الويب
@@ -132,7 +130,6 @@ negative6 = استمر
 
 [es]
 question = ¿Cuál es tu lenguaje de programación favorito?
-rust-extra = el nuevo lenguaje de programación creado por Mozilla.
 cpp-intro = ¿Así que te gustan los tiempos de compilación y los mensajes de error incomprensibles? Eso está bien, nosotros también. Podrías ayudar en
 cpp-gecko-extra = el motor que impulsa Firefox
 cpp-b2g-extra = el sistema operativo para teléfonos Android hecho con tecnologías web
@@ -193,7 +190,6 @@ negative6 = Sigue adelante
 
 [el]
 question = Ποια είναι η αγαπημένη σου γλώσσα προγραμματισμού;
-rust-extra = η νέα γλώσσα προγραμματισμού απ' το Mozilla.
 cpp-intro = Ώστε σ' αρέσουν τα πολύωρα compiles και τα ακατανόητα μηνύματα λάθους; Τέλεια! Και σε μας. Τι λες για...
 cpp-gecko-extra = η μηχανή που δίνει ζωή στον Firefox
 cpp-b2g-extra = το λειτουργικό σύστημα για smartphones βασισμένο σε web τεχνολογίες
@@ -254,7 +250,6 @@ negative6 = Πήγαινε παρακάτω
 
 [it]
 question = Qual è il tuo linguaggio di programmazione preferito?
-rust-extra = il nuovo linguaggio di programmazione creato da Mozilla.
 cpp-intro = Quindi ti piacciono le compilazioni lunghe ed i messaggi di errore incomprensibili? Perfetto, anche a noi. Ti propongo
 cpp-gecko-extra.innerHTML = il motore al cuore di <span lang="en">Firefox</span>
 cpp-b2g-extra.innerHTML = il sistema operativo per telefoni <span lang="en">Android</span> fondato sulle teconolgie del <span lang="en">web</span>
@@ -314,7 +309,6 @@ negative6 = Avanti il prossimo
 
 [fr]
 question = Quel est votre langage de programmation préféré ?
-rust-extra =  le nouveau langage de programmation de systèmes créé par Mozilla.
 cpp-intro = Alors vous aimez les compilations qui durent longtemps et les messages d'erreur incompréhensibles ? C'est cool, nous aussi. Vous pourriez travailler sur
 cpp-gecko-extra = le moteur qui fait fonctionner Firefox
 cpp-b2g-extra = le système d'exploitation pour téléphones Android basé sur les technologies web
@@ -377,7 +371,6 @@ negative6 = Essaie encore
 
 [ro]
 question = Care este limbajul tău de programare preferat?
-rust-extra = Noul limbaj de programare de la Mozilla.
 cpp-intro = Deci iți plac timpi mari de compilare și mesajele de eroare pe care nu le ințelegi? E mișto, ai putea să ajuți la
 cpp-gecko-extra = Motorul care pune în funcțiune Firefox
 cpp-b2g-extra = Sistemul de operare pentru telefoanele Android făcut cu tehnologii web
@@ -438,7 +431,6 @@ negative6 = Alceva nu ai?
 
 [pt-BR]
 question = Qual sua linguagem de programação preferida?
-rust-extra = a nova linguagem de programação de sistemas criada pela Mozilla.
 cpp-intro = Então você gosta de longos tempos de compilação e mensagens de erro incompreensíveis? Legal, nós também. Você poderia trabalhar em
 cpp-gecko-extra = o motor que impulsiona o Firefox
 cpp-b2g-extra = o sistema operacional para celulares Android construido com tecnologias web
@@ -498,7 +490,6 @@ negative6 = Próximo
 
 [zh-TW]
 question = 您最愛的程式語言是什麼？
-rust-extra = 由 Mozilla 所打造的全新系統化程式設計語言。
 cpp-intro = 所以你喜歡等程式慢慢編譯完成，還有費解的錯誤訊息？這樣很酷，我們也喜歡。您可以貢獻到
 cpp-gecko-extra = 驅動 Firefox 運作的引擎
 cpp-b2g-extra = 建立於網頁技術之上的 Android 手機作業系統
@@ -558,7 +549,6 @@ negative6 = 再來
 
 [de]
 question = In welcher Sprache programmierst Du am liebsten?
-rust-extra = die neue Systemprogrammiersprache von Mozilla.
 cpp-intro = Du magst also lange Kompilierungszeiten und unverständliche Fehlermeldungen? Das ist cool, wir auch. Du könntest arbeiten an
 cpp-gecko-extra = die Engine, welche Firefox vorantreibt
 cpp-b2g-extra = das Betriebssystem für Android Mobiltelefone basierend auf Webtechnologien
@@ -619,7 +609,6 @@ negative6 = Weiter
 
 [hi-IN]
 question = आपकी पसंदीदा प्रोग्रामिंग भाषा क्या है?
-rust-extra = मोज़िला के द्वारा बनाई गई नए सिस्टम प्रोग्रामिंग भाषा.
 cpp-intro = तो आपको लंबे समय और समझ से बाहर त्रुटि संदेश संकलन पसंद है? अच्छा है, हमे भी हैं. आप इस पर काम कर सकते हैं
 cpp-gecko-extra = फ़ायरफ़ॉक्स, इस इंजन पे काम करता है
 cpp-b2g-extra = वेब प्रौद्योगिकियों पर बनाया गया एंड्रॉयड फोन के लिए ऑपरेटिंग सिस्टम
@@ -685,7 +674,6 @@ negative6 = चलते रहो
 
 [zh-CN]
 question = 你最喜欢的程序语言是什么?
-rust-extra = 由 Mozilla 打造的全新系统化程序设计语言.
 cpp-intro = 所以你喜欢等程序慢慢编译完成, 还有费解的错误讯息? 这样很酷, 我们也很喜欢. 您可以贡献到
 cpp-gecko-extra = 驱动 Firefox 运作的引擎
 cpp-b2g-extra = 建立于网页技术之上的 Android 手机操作系统
@@ -745,7 +733,6 @@ negative6 = 再来
 
 [pl]
 question = Jaki jest twój ulubiony język programowania?
-rust-extra = nowy język programowania tworzony przez Mozillę
 cpp-intro = A więc lubisz długie czasy kompilacji i niezrozumiałe komunikaty o błędach? Świetnie, my także. Projekt nad którym mógłbyś pracować, to
 cpp-gecko-extra = silnik który napędza Firefoksa
 cpp-b2g-extra = system operacyjny dla telefonów Android budowany na technologiach webowych
@@ -811,7 +798,6 @@ negative6 = Dalej
 
 [tr]
 question = En sevdiğin programlama dili hangisi?
-rust-extra = Mozilla'nın ürünü sistem programlama dili.
 cpp-intro = Demek uzun derleme sürelerini ve anlaşılmaz hata mesajlarını seviyorsun. Bizim için hava hoş. Şunun üzerinde çalışabilirsin:
 cpp-gecko-extra = Firefox'a güç veren motor
 cpp-b2g-extra = Android telefonlar için, web teknolojileriyle geliştirilmiş işletim sistemi
@@ -871,7 +857,6 @@ negative5 = Uzmanlık alanım değil
 negative6 = Bekleme yapma
 [te]
 question = మీకు ఇష్టమైన ప్రోగ్రామింగ్ భాష ఏమిటి?
-rust-extra = మొజిల్లా సృష్టించిన కొత్త సిస్టమ్స్ ప్రోగ్రామింగ్ భాష.
 cpp-intro = మీరు ధీర్గమైన కంపైల్ సమయాన్ని మరియు అపారమైన పొరపాటు సందేశాలని ఇష్టపడతార ?
 cpp-gecko-extra = ఫైర్ఫాక్స్ నడిపే ఇంజిన్
 cpp-b2g-extra = వెబ్ టెక్నాలజీలపై నిర్మించిన ఆండ్రాయిడ్ ఫోన్ల కోసం ఆపరేటింగ్ సిస్టమ్
@@ -934,7 +919,6 @@ negative5 = నేను ఒక నిపుణుడు కాదు
 negative6 = మరొకదాన్ని చూపించు
 [nl]
 question = Wat is je favoriete programeer taal?
-rust-extra = de nieuwe systeem programmeer taal van Mozilla.
 cpp-intro = Dus je houdt van lange compilatie tijd en onbegrijpelijke foutmeldingen? Dat is cool, doen wij ook. Je zou kunnen werken aan
 cpp-gecko-extra = de Engine Firefox aandrijft
 cpp-b2g-extra = het besturings systeem voor android mobiele telefoons gebaseerd op web technologie
@@ -998,7 +982,6 @@ negative6 = blijven gaan
 
 [bn-BD]
 question = আপনার পছন্দনীয় প্রোগ্রামিং ল্যাঙ্গুয়েজ কোনটি?
-rust-extra = মোজিলার তৈরী নতুন সিস্টেম প্রোগ্রামিং ল্যাঙ্গুয়েজ।
 cpp-intro = আপনি তাহলে দীর্ঘ কম্পাইলিং সময় আর অসম্ভব সকল ত্রুটি বার্তা পছন্দ করেন। চমৎকার, আমরাও তাই পছন্দ করি। আপনি এটির উপর কাজ করতে পারেন
 cpp-gecko-extra = ফায়ারফক্স এই ইঞ্জিনেই চালিত হয়
 cpp-b2g-extra = ওয়েব প্রযুক্তির উপর ভিত্তি করে বানানো এন্ড্রয়েড ফোনের জন্যে অপারেটিং সিস্টেম


### PR DESCRIPTION
This string isn't used in current version of site, so we shouldn't ask to translate it.
