### PR TITLE
Add lang-selection string to all locales

### DIFF
--- a/index.html
+++ b/index.html
@@ -22,7 +22,7 @@
 
   <a href="http://www.mozilla.org/" id="tabzilla">mozilla</a>
   <div id="lang">
-    <span data-l10n-id="lang-selection">language: </span>
+    <span data-l10n-id="lang-selection">Language:</span>
     <select>
       <option value='ar'>ar</option>
       <option value='bn-BD'>bn-BD</option>

--- a/locales.ini
+++ b/locales.ini
@@ -1,4 +1,5 @@
 ﻿[en]
+lang-selection = Language:
 question = What's your favourite programming language?
 cpp-intro = So you like long compile times and incomprehensible error messages? That's cool, we do too. You could work on
 cpp-gecko-extra = the engine that drives Firefox
@@ -67,6 +68,7 @@ negative5 = Not my line of expertise
 negative6 = Keep going
 
 [ar]
+lang-selection = Language:
 question = ما هي لغة البرمجة المفضلة لديك؟
 cpp-intro = تريد تجميع طويلة مرات، ورسائل خطأ غير مفهومة؟ هذا هو بارد، ونحن نفعل أيضا. هل يمكن أن تعمل على بهذا
 cpp-gecko-extra = المحرك الذي يدفع فايرفوكس
@@ -130,6 +132,7 @@ negative5 = أي خبرة
 negative6 = استمر
 
 [es]
+lang-selection = Idioma:
 question = ¿Cuál es tu lenguaje de programación favorito?
 cpp-intro = ¿Así que te gustan los tiempos de compilación y los mensajes de error incomprensibles? Eso está bien, nosotros también. Podrías ayudar en
 cpp-gecko-extra = el motor que impulsa Firefox
@@ -190,6 +193,7 @@ negative5 = No es mi línea de especialización
 negative6 = Sigue adelante
 
 [el]
+lang-selection = Γλώσσα:
 question = Ποια είναι η αγαπημένη σου γλώσσα προγραμματισμού;
 cpp-intro = Ώστε σ' αρέσουν τα πολύωρα compiles και τα ακατανόητα μηνύματα λάθους; Τέλεια! Και σε μας. Τι λες για...
 cpp-gecko-extra = η μηχανή που δίνει ζωή στον Firefox
@@ -250,6 +254,7 @@ negative5 = Όχι ο τομέας μου
 negative6 = Πήγαινε παρακάτω
 
 [it]
+lang-selection = Lingua:
 question = Qual è il tuo linguaggio di programmazione preferito?
 cpp-intro = Quindi ti piacciono le compilazioni lunghe ed i messaggi di errore incomprensibili? Perfetto, anche a noi. Ti propongo
 cpp-gecko-extra.innerHTML = il motore al cuore di <span lang="en">Firefox</span>
@@ -309,6 +314,7 @@ negative5 = Non sono competente
 negative6 = Avanti il prossimo
 
 [fr]
+lang-selection = Langue:
 question = Quel est votre langage de programmation préféré ?
 cpp-intro = Alors vous aimez les compilations qui durent longtemps et les messages d'erreur incompréhensibles ? C'est cool, nous aussi. Vous pourriez travailler sur
 cpp-gecko-extra = le moteur qui fait fonctionner Firefox
@@ -372,6 +378,7 @@ negative5 = Pas mon champ d'expertise
 negative6 = Essaie encore
 
 [ro]
+lang-selection = Limbă:
 question = Care este limbajul tău de programare preferat?
 cpp-intro = Deci iți plac timpi mari de compilare și mesajele de eroare pe care nu le ințelegi? E mișto, ai putea să ajuți la
 cpp-gecko-extra = Motorul care pune în funcțiune Firefox
@@ -432,6 +439,7 @@ negative5 = Nu întră în competențele mele
 negative6 = Alceva nu ai?
 
 [pt-BR]
+lang-selection = Idioma:
 question = Qual sua linguagem de programação preferida?
 cpp-intro = Então você gosta de longos tempos de compilação e mensagens de erro incompreensíveis? Legal, nós também. Você poderia trabalhar em
 cpp-gecko-extra = o motor que impulsiona o Firefox
@@ -491,6 +499,7 @@ negative5 = Não é minha especialidade
 negative6 = Próximo
 
 [zh-TW]
+lang-selection = Language:
 question = 您最愛的程式語言是什麼？
 cpp-intro = 所以你喜歡等程式慢慢編譯完成，還有費解的錯誤訊息？這樣很酷，我們也喜歡。您可以貢獻到
 cpp-gecko-extra = 驅動 Firefox 運作的引擎
@@ -550,6 +559,7 @@ negative5 = 不是我的專業
 negative6 = 再來
 
 [de]
+lang-selection = Sprache:
 question = In welcher Sprache programmierst Du am liebsten?
 cpp-intro = Du magst also lange Kompilierungszeiten und unverständliche Fehlermeldungen? Das ist cool, wir auch. Du könntest arbeiten an
 cpp-gecko-extra = die Engine, welche Firefox vorantreibt
@@ -610,6 +620,7 @@ negative5 = Nicht meine Expertise
 negative6 = Weiter
 
 [hi-IN]
+lang-selection = Language:
 question = आपकी पसंदीदा प्रोग्रामिंग भाषा क्या है?
 cpp-intro = तो आपको लंबे समय और समझ से बाहर त्रुटि संदेश संकलन पसंद है? अच्छा है, हमे भी हैं. आप इस पर काम कर सकते हैं
 cpp-gecko-extra = फ़ायरफ़ॉक्स, इस इंजन पे काम करता है
@@ -675,6 +686,7 @@ negative5 = कोई अनुभव नहीं
 negative6 = चलते रहो
 
 [zh-CN]
+lang-selection = Language:
 question = 你最喜欢的程序语言是什么?
 cpp-intro = 所以你喜欢等程序慢慢编译完成, 还有费解的错误讯息? 这样很酷, 我们也很喜欢. 您可以贡献到
 cpp-gecko-extra = 驱动 Firefox 运作的引擎
@@ -734,6 +746,7 @@ negative5 = 不是我的专业
 negative6 = 再来
 
 [pl]
+lang-selection = Język:
 question = Jaki jest twój ulubiony język programowania?
 cpp-intro = A więc lubisz długie czasy kompilacji i niezrozumiałe komunikaty o błędach? Świetnie, my także. Projekt nad którym mógłbyś pracować, to
 cpp-gecko-extra = silnik który napędza Firefoksa
@@ -799,6 +812,7 @@ negative5 = Nie moja dziedzina
 negative6 = Dalej
 
 [tr]
+lang-selection = Dil:
 question = En sevdiğin programlama dili hangisi?
 cpp-intro = Demek uzun derleme sürelerini ve anlaşılmaz hata mesajlarını seviyorsun. Bizim için hava hoş. Şunun üzerinde çalışabilirsin:
 cpp-gecko-extra = Firefox'a güç veren motor
@@ -859,6 +873,7 @@ negative5 = Uzmanlık alanım değil
 negative6 = Bekleme yapma
 
 [te]
+lang-selection = Language:
 question = మీకు ఇష్టమైన ప్రోగ్రామింగ్ భాష ఏమిటి?
 cpp-intro = మీరు ధీర్గమైన కంపైల్ సమయాన్ని మరియు అపారమైన పొరపాటు సందేశాలని ఇష్టపడతార ?
 cpp-gecko-extra = ఫైర్ఫాక్స్ నడిపే ఇంజిన్
@@ -922,6 +937,7 @@ negative5 = నేను ఒక నిపుణుడు కాదు
 negative6 = మరొకదాన్ని చూపించు
 
 [nl]
+lang-selection = Taal:
 question = Wat is je favoriete programeer taal?
 cpp-intro = Dus je houdt van lange compilatie tijd en onbegrijpelijke foutmeldingen? Dat is cool, doen wij ook. Je zou kunnen werken aan
 cpp-gecko-extra = de Engine Firefox aandrijft
@@ -985,6 +1001,7 @@ negative5 = Niet mijn soort van ervaring
 negative6 = blijven gaan
 
 [bn-BD]
+lang-selection = Language:
 question = আপনার পছন্দনীয় প্রোগ্রামিং ল্যাঙ্গুয়েজ কোনটি?
 cpp-intro = আপনি তাহলে দীর্ঘ কম্পাইলিং সময় আর অসম্ভব সকল ত্রুটি বার্তা পছন্দ করেন। চমৎকার, আমরাও তাই পছন্দ করি। আপনি এটির উপর কাজ করতে পারেন
 cpp-gecko-extra = ফায়ারফক্স এই ইঞ্জিনেই চালিত হয়


### PR DESCRIPTION
In gh-110 lang-selection string was added only to ru-RU locale. This resulted in erroneous (Russian) string being shown for other languages, when either:
- User selected "ru-RU" from select box;
- User had "ru-RU" locale set-up in browser and opened any asknot page, including visits from permalinks.

Solution is quite straightforward - include lang-selection string for all locales.

As I am obviously not proficient in all changed languages, translations were taken from:
- http://transvision.mozfr.org/string/?entity=browser/chrome/browser/preferences/languages.dtd:languages.customize.selectLanguage.label&repo=central
- http://transvision.mozfr.org/string/?entity=mobile/android/chrome/localepicker.properties:chooseLanguage&repo=central

For Asian/Arabic/non-Latin script locales there is sadly no translation available, and it is left to corresponding translators to fix this one up.

Closes gh-71
Fixes gh-111
