### PR TITLE
Remove "cpp-v8-extra" string from locales

### DIFF
--- a/locales.ini
+++ b/locales.ini
@@ -6,7 +6,6 @@ cpp-gecko-extra = the engine that drives Firefox
 cpp-b2g-extra = the operating system for Android phones built on web technologies
 cpp-thunderbird-extra = the open source email client
 cpp-seamonky-extra = the open source web productivity suite
-cpp-v8-extra = implementing the v8 API on top of Spidermonkey
 cpp-ems-extra = creating a LLVM-to-JS system to allow porting native code to the web
 cpp-svg-extra.innerHTML = help with the implementation and testing of Mozilla's <a href="https://developer.mozilla.org/en-US/docs/SVG">Scalable Vector Graphics</a> engine
 cpp-win8-extra = the Metro-style enabled desktop browser for Windows 8
@@ -76,7 +75,6 @@ cpp-gecko-extra = المحرك الذي يدفع فايرفوكس
 cpp-b2g-extra = نظام التشغيل للهواتف أندرويد مبنية على تقنيات الويب
 cpp-thunderbird-extra = برنامج البريد الإلكتروني المجاني والمفتوح
 cpp-seamonky-extra = المصدر جناح الإنتاجية فتح ويب
-cpp-v8-extra = بتنفيذ API V8 على أعلى من Spidermonkey
 cpp-ems-extra = إنشاء نظام LLVM إلى JS للسماح ترقية التعليمات البرمجية الأصلية على شبكة الإنترنت
 cpp-svg-extra.innerHTML = مساعدة في تنفيذ واختبار وموزيلا <a href="https://developer.mozilla.org/en-US/docs/SVG">Scalable Vector Graphics</a> engine
 cpp-win8-extra = لتمكين متصفح سطح المكتب على غرار مترو لنظام التشغيل Windows 8
@@ -140,7 +138,6 @@ cpp-gecko-extra = el motor que impulsa Firefox
 cpp-b2g-extra = el sistema operativo para teléfonos Android hecho con tecnologías web
 cpp-thunderbird-extra = el cliente de correo electrónico de código abierto
 cpp-seamonky-extra = el conjunto de herramientas de código abierto para la web
-cpp-v8-extra = la implementación de V8 API por encima de Spidermonkey
 cpp-ems-extra = la creación de un sistema LLVM-to-JS para permitir portar el codigo nativo a la web
 cpp-svg-extra.innerHTML = ayuda con la implementación y las pruebas de el motor de <a href="https://developer.mozilla.org/es/docs/SVG">Gráficos Vectoriales Redimensionables (SVG)</a> de Mozilla
 cpp-win8-extra = el navegador compatible con Metro para Windows 8
@@ -201,7 +198,6 @@ cpp-gecko-extra = η μηχανή που δίνει ζωή στον Firefox
 cpp-b2g-extra = το λειτουργικό σύστημα για smartphones βασισμένο σε web τεχνολογίες
 cpp-thunderbird-extra = o open source email client
 cpp-seamonky-extra = η open source web σουίτα παραγωγικότητας
-cpp-v8-extra = ενωματώνοντας το V8 API πάνω απ' το Spidermonkey
 cpp-ems-extra = δημιουργώντας ένα LLVM-to-JS σύστημα για γίνει δυνατή η μεταφορά native κώδικα στο web
 cpp-svg-extra.innerHTML = βοήθησε με την ενσωμάτωση και τη δοκιμή της μηχανής για <a href="https://developer.mozilla.org/en-US/docs/SVG">Διανυσματικά Γραφικά</a> του Mozilla
 cpp-win8-extra = ο προσαρμοσμένος στο Metro browser για Windows 8
@@ -262,7 +258,6 @@ cpp-gecko-extra.innerHTML = il motore al cuore di <span lang="en">Firefox</span>
 cpp-b2g-extra.innerHTML = il sistema operativo per telefoni <span lang="en">Android</span> fondato sulle teconolgie del <span lang="en">web</span>
 cpp-thunderbird-extra.innerHTML = l'applicazione per la posta elettronica <span lang="en">open source</span>
 cpp-seamonky-extra.innerHTML = la <span lang="fr">suite</span> di strumenti <span lang="en">open source</span> di strumenti per il <span lang="en">web</span>
-cpp-v8-extra.innerHTML = implementare l'API v8 in <span lang="en">Spidermonkey</span>
 cpp-ems-extra.innerHTML = creare un sistema LLVM-to-JS per consentire di portare il codice nativo verso il <span lang="en">web</span>
 cpp-svg-extra.innerHTML = aiutare con l'implementazione e le verifiche del motore <a href="https://developer.mozilla.org/en-US/docs/SVG" lang="en">Scalable Vector Graphics</a> di Mozilla
 cpp-win8-extra.innerHTML = il navigatore per <span lang="en">desktop</span> per <span lang="en">Windows 8</span> pronto per l'interfaccia Metro
@@ -322,7 +317,6 @@ cpp-gecko-extra = le moteur qui fait fonctionner Firefox
 cpp-b2g-extra = le système d'exploitation pour téléphones Android basé sur les technologies web
 cpp-thunderbird-extra = le client mail open source
 cpp-seamonky-extra = la suite web open source pour la productivité
-cpp-v8-extra = implémenter l'API v8 par dessus Spidermonkey
 cpp-ems-extra = créer un système LLVM-vers-JS pour permettre de porter du code natif vers le Web
 cpp-svg-extra.innerHTML = aider à l'implémentation et aux tests du moteur <a href="https://developer.mozilla.org/fr/docs/SVG">Scalable Vector Graphics</a> de Mozilla
 cpp-win8-extra = le navigateur web de bureau pour Windows 8 pouvant utiliser le style Metro
@@ -386,7 +380,6 @@ cpp-gecko-extra = Motorul care pune în funcțiune Firefox
 cpp-b2g-extra = Sistemul de operare pentru telefoanele Android făcut cu tehnologii web
 cpp-thunderbird-extra = Clientul de e-mail
 cpp-seamonky-extra = suita web de productivitate
-cpp-v8-extra = Implementarea a API-ului v8 în Spidermonkey
 cpp-ems-extra = crearea unui sistem LLVM-to-JS pentru portarea codului nativ în cod web
 cpp-svg-extra.innerHTML = ajută la implementarea și testarea motorului Mozilla de <a href="https://developer.mozilla.org/en-US/docs/SVG">grafică vectorială proporționabilă</a>
 cpp-win8-extra = adică să integrezi stilul Metro pentru Windows 8
@@ -447,7 +440,6 @@ cpp-gecko-extra = o motor que impulsiona o Firefox
 cpp-b2g-extra = o sistema operacional para celulares Android construido com tecnologias web
 cpp-thunderbird-extra = o cliente de e-mails em código aberto
 cpp-seamonky-extra = a suíte de produtividade web em código aberto
-cpp-v8-extra = implmentando a API v8 no Spidermonkey
 cpp-ems-extra = criando um sistema LLVM-para-JS para permitir a portabilidade de código nativo para a web
 cpp-svg-extra.innerHTML = ajudar na implementação e testes do mecanismo de <a href="https://developer.mozilla.org/en-US/docs/SVG">Scalable Vector Graphics</a> da Mozilla
 cpp-win8-extra = o navegador com estilo Metro para Windows 8
@@ -507,7 +499,6 @@ cpp-gecko-extra = 驅動 Firefox 運作的引擎
 cpp-b2g-extra = 建立於網頁技術之上的 Android 手機作業系統
 cpp-thunderbird-extra = 開放原始碼的電子郵件軟體
 cpp-seamonky-extra = 開放原始碼的網頁套裝軟體大補包
-cpp-v8-extra = 在 Spidermonkey 上實作 v8 API
 cpp-ems-extra = 開發一套 LLVM-to-JS 系統，讓您可以將原生程式碼移植到網頁上
 cpp-svg-extra.innerHTML = 幫助實作與測試 Mozilla 的 <a href="https://developer.mozilla.org/en-US/docs/SVG">可縮放向量圖形</a> 引擎
 cpp-win8-extra = Windows 8 Metro 風格的桌面瀏覽器
@@ -577,7 +568,6 @@ cpp-gecko-extra = die Engine, welche Firefox vorantreibt
 cpp-b2g-extra = das Betriebssystem für Android Mobiltelefone basierend auf Webtechnologien
 cpp-thunderbird-extra = dem Open Source E-Mail Client
 cpp-seamonky-extra = die Open Source Web Productivity Suite
-cpp-v8-extra = einer Umsetzung von der v8 API auf Spidermonkey
 cpp-ems-extra = Erstellen eines LLVM-to-JS Systems um native Code ins Internet zu portieren
 cpp-svg-extra.innerHTML = Helfe bei der Umsetzung und dem Testen von Mozillas Engine für <a href="https://developer.mozilla.org/en-US/docs/SVG">skalierbare Vektor Graphiken</a> 
 cpp-win8-extra = der Desktopbrowser für Windows 8 mit Metro-style 
@@ -638,7 +628,6 @@ cpp-gecko-extra = फ़ायरफ़ॉक्स, इस इंजन पे 
 cpp-b2g-extra = वेब प्रौद्योगिकियों पर बनाया गया एंड्रॉयड फोन के लिए ऑपरेटिंग सिस्टम
 cpp-thunderbird-extra = ओपन सोर्स ईमेल क्लाइंट
 cpp-seamonky-extra = ओपन सोर्स वेब उत्पादकता सुइट
-cpp-v8-extra = Spidermonkey के ऊपर पर वी 8 एपीआई को लागू करने के
 cpp-ems-extra = वेब के लिए पोर्टिंग प्राकृत कोड की अनुमति के लिए एक LLVM के लिए JS प्रणाली
 cpp-svg-extra.innerHTML = मोज़िला <a href="https://developer.mozilla.org/en-US/docs/SVG"> स्केलेबल वेक्टर ग्राफिक्स </ a> के कार्यान्वयन और परीक्षण इंजन के साथ मदद
 cpp-win8-extra = विंडोज 8 के लिए मेट्रो शैली की सक्षम डेस्कटॉप ब्राउज़र
@@ -704,7 +693,6 @@ cpp-gecko-extra = 驱动 Firefox 运作的引擎
 cpp-b2g-extra = 建立于 Web 技术之上的 Android 移动操作系统
 cpp-thunderbird-extra = 开源的电子邮件客户端
 cpp-seamonky-extra = 开源的网站开发套装
-cpp-v8-extra = 在 Spidermonkey 基础上实现的 v8 API
 cpp-ems-extra = 开发一套 LLVM-to-JS 的系统，让你可以将原生的代码移植到网页上
 cpp-svg-extra.innerHTML = 帮助实现和测试 Mozilla 的 <a href="https://developer.mozilla.org/zh-CN/docs/SVG">SVG</a> 引擎
 cpp-win8-extra = 适用 Windows 8 的 Metro 风格桌面浏览器
@@ -774,7 +762,6 @@ cpp-gecko-extra = silnik który napędza Firefoksa
 cpp-b2g-extra = system operacyjny dla telefonów Android budowany na technologiach webowych
 cpp-thunderbird-extra = open-source'owy klient poczty
 cpp-seamonky-extra = sieciowy, open-source'owy pakiet biurowy
-cpp-v8-extra = implementacja API v8 nadbudowująca Spidermonkey
 cpp-ems-extra = tworzenie systemu LLVM-to-JS który pozwoli na portowanie natywnego kodu do sieci
 cpp-svg-extra.innerHTML = pomoc w implementacji i testowaniu silnika <a href="https://developer.mozilla.org/pl/docs/SVG">SVG (Skalowalnych Grafik Wektorowych)</a> Mozilli
 cpp-win8-extra = przeglądarka dla Windows 8 przystosowana pod styl Metro
@@ -840,7 +827,6 @@ cpp-gecko-extra = Firefox'a güç veren motor
 cpp-b2g-extra = Android telefonlar için, web teknolojileriyle geliştirilmiş işletim sistemi
 cpp-thunderbird-extra = açık kaynaklı e-posta istemcisi
 cpp-seamonky-extra = açık kaynaklı web üretkenlik seti
-cpp-v8-extra = Spidermonkey tabanlı v8 API geliştirme
 cpp-ems-extra = native kodu web'e uyarlamak için LLVM'den JS'e çevirici yapıyoruz
 cpp-svg-extra.innerHTML = Mozilla'nın <a href="https://developer.mozilla.org/en-US/docs/SVG">Ölçeklenebilir Vektör Grafik</a> motorunun geliştirilmesi ve test edilmesine yardımcı ol
 cpp-win8-extra = Windows 8 için Metro tarzı masaüstü tarayıcı
@@ -901,7 +887,6 @@ cpp-gecko-extra = ఫైర్ఫాక్స్ నడిపే ఇంజిన
 cpp-b2g-extra = వెబ్ టెక్నాలజీలపై నిర్మించిన ఆండ్రాయిడ్ ఫోన్ల కోసం ఆపరేటింగ్ సిస్టమ్
 cpp-thunderbird-extra = ఓపెన్ సోర్స్ ఈమెయిల్ క్లైంట్
 cpp-seamonky-extra = ఓపెన్ సోర్స్ వెబ్ ఉత్పాదకత సూట్ను
-cpp-v8-extra = Spidermonkey పై V8 API అమలు చేయడం
 cpp-ems-extra = వెబ్ పోర్టింగ్ స్థానిక కోడ్ అనుమతించేందుకు ఒక LLVM నుండి JS వ్యవస్థ సృష్టించడం
 cpp-svg-extra.innerHTML = మొజిల్లా యొక్క <a href="https://developer.mozilla.org/en-US/docs/SVG"> స్కేలబుల్ వెక్టార్ గ్రాఫిక్స్ </ a> అమలు మరియు పరీక్ష ఇంజన్ విషయంలో సహాయపడేందుకు
 cpp-win8-extra = Windows 8 మెట్రో-స్టైల్ డెస్క్టాప్ బ్రౌజర్ లో తోడ్పడింది
@@ -965,7 +950,6 @@ cpp-gecko-extra = de Engine Firefox aandrijft
 cpp-b2g-extra = het besturings systeem voor android mobiele telefoons gebaseerd op web technologie
 cpp-thunderbird-extra = de open source email client
 cpp-seamonky-extra = de open source web productivity suite
-cpp-v8-extra = implementatie van de v8 API bovenop Spidermonkey
 cpp-ems-extra = het creëren van een LLVM-to-JS system voor het overzetten van natieve code naar het web
 cpp-svg-extra.innerHTML = help met de implementatie en het testen van Mozilla's <a href="https://developer.mozilla.org/en-US/docs/SVG">Scalable Vector Graphics</a> engine
 cpp-win8-extra = de desktop browser voor Windows 8 met Metro-stijl
@@ -1029,7 +1013,6 @@ cpp-gecko-extra = ফায়ারফক্স এই ইঞ্জিনেই �
 cpp-b2g-extra = ওয়েব প্রযুক্তির উপর ভিত্তি করে বানানো এন্ড্রয়েড ফোনের জন্যে অপারেটিং সিস্টেম
 cpp-thunderbird-extra = ওপেন সোর্স ইমেইল ক্লায়েন্ট
 cpp-seamonky-extra = ওপেন সোর্স ওয়েব প্রডাক্টিভিটি স্যুট
-cpp-v8-extra = স্পাইডারমাঙ্কি এর উপর ভি৮ এপিআই বাস্তবায়ন করা
 cpp-ems-extra =  ওয়েবে প্রাকৃত (native) কোড পোর্টিং করতে LLVM থেকে JS তৈরীর একটি প্রণালী
 cpp-svg-extra.innerHTML = মজিলার <a href="https://developer.mozilla.org/en-US/docs/SVG">পরিবর্তনযোগ্য ভেক্টর গ্রাফিক্স</ a> ইঞ্জিন বাস্তবায়ন ও পরিক্ষা করতে সহায়তা করুন
 cpp-win8-extra = উইন্ডোজ ৮ এর জন্যে মেট্রো-স্টাইল সক্রিয় ডেস্কটপ
@@ -1093,7 +1076,6 @@ cpp-gecko-extra = движком вывода веб-страниц Firefox
 cpp-b2g-extra = операционной системой для телефонов Android на базе веб-технологий
 cpp-thunderbird-extra = свободным почтовым клиентом
 cpp-seamonky-extra = свободным набором программ для работы в Интернете
-cpp-v8-extra = имплементацией API v8 поверх Spidermonkey
 cpp-ems-extra = созданием LLVM-to-JS системы, которая позволит портировать нативный код в Сеть
 cpp-svg-extra.innerHTML = имплементацией и тестированием движка <a href="https://ru.wikipedia.org/wiki/SVG">SVG</a> от Mozilla
 cpp-win8-extra = браузером для Windows 8 в стиле Metro
@@ -1163,7 +1145,6 @@ cpp-gecko-extra = dziņa, kas darbina Firefox pārlūku
 cpp-b2g-extra = uz tīmekļa tehnoloģijām balstītās operētājsistēmas Android viedtālruņiem
 cpp-thunderbird-extra = atvērtā pirmkoda e-pasta klienta
 cpp-seamonky-extra = atvērtā pirmkoda tīmekļa lietojumuprogrammu komplekta
-cpp-v8-extra = v8 saskarnes API pa virsu Spidermonkey
 cpp-ems-extra = LLVM-uz-JS pirmkoda portēšanas sistēmas izstrādes, kas ļaus izmantot vietējo kodu tīmekļa lapās
 cpp-svg-extra.innerHTML = Mozilla <abbr title="Mērogojamās vektoru grafikas">SVG</abbr> dziņa ieviešanas un testēšanas
 cpp-win8-extra = Metro-stila galddatoru pārlūprogrammas Windows 8 platformai


### PR DESCRIPTION
As the choice itself was pruned in 0aa78e7 (see gh-129), logical thing is to get rid of its translations too.
