### PR TITLE
'Open in new tab' and 'copy link' on the buttons - issue #215

### DIFF
--- a/foopy.js
+++ b/foopy.js
@@ -99,6 +99,9 @@
     }
 
     function investigate(ev) {
+        if(ev.which === 2) {
+          return;
+        }
         ev.preventDefault();
         var choice = $('.choices li', groupNode)[choices[choices.length - 1][choiceIndex[choiceIndex.length - 1]]];
         if (choice.hasAttribute('next-group')) {
@@ -109,7 +112,10 @@
         }
     }
 
-    function takeBack() {
+    function takeBack(ev) {
+        if(ev.which === 2) {
+          return;
+        }
         cleanUpCurrent();
         setLocationHashSuffix("");
         stack.splice(stack.length - 1, 1);


### PR DESCRIPTION
This PR adds the correct hrefs to all of the buttons, so users can do things like middle clicking, open in new tab, copy link, etc.

I also moved the code for incrementing choiceIndex into it's own function so it could be referenced by both nextChoice (as it was before) and updateCurrentChoice (to get a link for the 'next' button).

Last thing to mention would be that I named the next choice variable 'nextChoice' to keep in line with the naming of lastChoice, but that could cause some problems if someone ever decides to call nextChoice (the function) from within updateCurrentChoice.

Tested in IE 11.0.9600.17207, Nightly 34.0a1 (2014-07-24), and Chrome 35.0.1916.114m
