### PR TITLE
Add Treeherder to js/py programming language categories (1046596)

### DIFF
--- a/index.html
+++ b/index.html
@@ -299,7 +299,7 @@
           <div class="extra" data-l10n-id="js-webdev-extra"></div>
         </li>
         <li target="https://github.com/mozilla/treeherder-ui/" data-choice-id="treeherder">Treeherder
-          <div class="extra" data-l10n-id="js-treeherder-extra"></div>
+          <div class="extra" data-l10n-id="treeherder-extra"></div>
         </li>
         <li target="http://www.benmoskowitz.com/?p=527" data-choice-id="popcorn">Popcorn
           <div class="extra" data-l10n-id="js-popcorn-extra"></div>
@@ -359,7 +359,7 @@
           <div class="extra" data-l10n-id="py-releng-extra"></div>
         </li>
         <li target="https://github.com/mozilla/treeherder-ui/" data-choice-id="treeherder">Treeherder
-          <div class="extra" data-l10n-id="py-treeherder-extra"></div>
+          <div class="extra" data-l10n-id="treeherder-extra"></div>
         </li>
       </ul>
     </div>

--- a/locales/en.ini
+++ b/locales/en.ini
@@ -25,6 +25,7 @@ advocate-intro = So you like telling people about Mozilla? You could help with
 aff-extra = show your Mozilla and Firefox pride
 evan-extra = explain to web authors how to write for the open web
 translate-intro = So you speak a language that is not English? You could translate
+treeherder-extra = backend and reporting dashboard for Mozilla checkins
 l10nweb-extra = all of the major Mozilla web pages
 l10n-extra-tb = the email client available in more than 50 languages
 l10n-extra-ff = the browser available in more than 80 languages
@@ -60,7 +61,6 @@ js-thunderbird-extra = the open source email client
 js-seamomky-extra = the open source web productivity suite
 js-instantbird-extra = the open source, extensible, multi-protocol chat client
 js-webdev-extra = we have many large, complicated projects that use JavaScript
-js-treeherder-extra = data model, web service, and reporting dashboard for Mozilla checkins
 js-popcorn-extra = create interactive media pages that seamlessly integrate video, audio, and traditional web technologies
 js-persona-extra = implement a new way to safely and easily sign into websites
 js-firebug-extra = The most popular and powerful web development tool
@@ -83,7 +83,6 @@ py-dxr-extra = the intelligent source code indexing system
 py-tools-extra = various projects to facilitate easier automated testing of products
 py-webqa-extra = create automated tests for Mozilla's websites
 py-releng-extra = Mozilla's build, test, and release pipeline
-py-treeherder-extra = data model, web service, and reporting dashboard for Mozilla checkins
 php-intro = So you like your variable names to include dollar signs? That's cool, everyone misses Perl once in a while. You can work on
 php-wordpress-extra.innerHTML = the code that runs our <a href="http://blog.mozilla.org">blogs</a>
 php-marketplace-extra.innerHTML =  the PHP client for <a href="https://marketplace.firefox.com">Marketplace</a>


### PR DESCRIPTION
This fixes part 1 of Bugzilla bug [1046596](https://bugzilla.mozilla.org/show_bug.cgi?id=1046596).

This adds the suitable Treeherder content to both js/py categories. @jdm please check to make sure the py granularity level (ie. a sibling to items like "Release Enginnering" and "Firefox") makes sense to you. I've only updated en.ini based on the older checkins to the repo where new items were similarly added. I assume the other locales get suitably generated.

Let me know if I've missed something. I've iterated with @jeads on the wording and he's happy with it.

Tested on Windows:
FF Release **31.0**
Chrome Latest Release **36.0.1985.125 m**
