### PR TITLE
update treeherder url

### DIFF
--- a/index.html
+++ b/index.html
@@ -325,7 +325,7 @@
         <li target="https://wiki.mozilla.org/Webdev/GetInvolved" data-choice-id="web-development">Web development
           <div class="extra" data-l10n-id="js-webdev-extra"></div>
         </li>
-        <li target="https://github.com/mozilla/treeherder-ui/" data-choice-id="treeherder">Treeherder
+        <li target="https://github.com/mozilla/treeherder/" data-choice-id="treeherder">Treeherder
           <div class="extra" data-l10n-id="treeherder-extra"></div>
         </li>
         <li target="http://www.benmoskowitz.com/?p=527" data-choice-id="popcorn">Popcorn
@@ -388,7 +388,7 @@
         <li target="https://wiki.mozilla.org/ReleaseEngineering/Contribute" data-choice-id="releng-py">Release Engineering
           <div class="extra" data-l10n-id="py-releng-extra"></div>
         </li>
-        <li target="https://github.com/mozilla/treeherder-ui/" data-choice-id="treeherder">Treeherder
+        <li target="https://github.com/mozilla/treeherder/" data-choice-id="treeherder">Treeherder
           <div class="extra" data-l10n-id="treeherder-extra"></div>
         </li>
       </ul>


### PR DESCRIPTION
Treeherder https://github.com/mozilla/treeherder-ui-deprecated is closed. New repo is https://github.com/mozilla/treeherder