### PR TITLE
Buttons split awkwardly on small screens

### DIFF
--- a/style.css
+++ b/style.css
@@ -23,13 +23,13 @@ html {
 
 @media screen and (min-width: 500px) and (max-width: 760px) {
     #tabzilla {
-	margin-right: 60px;
+        margin-right: 60px;
     }
 }
 
 @media screen and (max-width: 499px) {
     #tabzilla {
-	margin-right: 50px;
+        margin-right: 50px;
     }
 }
 
@@ -53,6 +53,12 @@ html {
     margin-top:0px;
     text-align: center;
     padding-top: 60px;
+}
+
+@media screen and (max-width: 360px) {
+    #wrapper {
+        padding-top: 100px;
+    }
 }
 
 #ribbon {

--- a/style.css
+++ b/style.css
@@ -143,7 +143,7 @@ a {
     border: 0 none;
 
     display: inline-block;
-    max-width: 80%;
+    max-width: 90%;
 }
 
 #ok a {

--- a/style.css
+++ b/style.css
@@ -141,6 +141,9 @@ a {
     padding: 2px 10px 8px;
     border-radius: 6px;
     border: 0 none;
+
+    display: inline-block;
+    max-width: 80%;
 }
 
 #ok a {


### PR DESCRIPTION
Buttons were split awkwardly across multiple lines on small screen sizes. I fixed the CSS such that the button will appear cohesive at all times. Fixes #260.

![resizing](https://cloud.githubusercontent.com/assets/1653573/9319147/27cc180e-4519-11e5-9dcc-887c5865ba30.gif)

I also updated the placement of the Language Selection on screens <360px (it used to fight the "What's your area of expertise" element, which can also be seen in the images attached to #260).