### PR TITLE
Add language names in native languages

### DIFF
--- a/index.html
+++ b/index.html
@@ -35,35 +35,35 @@
   <div id="lang">
     <span id="lang-selection" data-l10n-id="lang-selection">Language:</span>
     <select>
-      <option value='ar'>ar</option>
-      <option value='bn-BD'>bn-BD</option>
-      <option value='bn-IN'>bn-IN</option>
-      <option value='de'>de</option>
-      <option selected value='en'>en</option>
-      <option value='es'>es</option>
-      <option value='fa'>fa</option>
-      <option value='fr'>fr</option>
-      <option value='el'>gr</option>
-      <option value='gu-IN'>gu-IN</option>
-      <option value='hi-IN'>hi-IN</option>
-      <option value='id'>id</option>
-      <option value='it'>it</option>
-      <option value='ko'>ko</option>
-      <option value='lv'>lv</option>
-      <option value='ml-IN'>ml-IN</option>
-      <option value='ne-NP'>ne-NP</option>
-      <option value='nl'>nl</option>
-      <option value='pl'>pl</option>
-      <option value='pt-BR'>pt-BR</option>
-      <option value='pt-PT'>pt-PT</option>
-      <option value='ro'>ro</option>
-      <option value='ru-RU'>ru-RU</option>
-      <option value='sq'>sq</option>
-      <option value='sv-SE'>sv-SE</option>
-      <option value='te'>te</option>
-      <option value='tr'>tr</option>
-      <option value='zh-CN'>zh-CN</option>
-      <option value='zh-TW'>zh-TW</option>
+      <option value='ar'>عربي | Arabic</option>
+      <option value='bn-BD'>বাংলা‬ (বাংলাদেশ) | Bengali (Bangladesh)</option>
+      <option value='bn-IN'>বাংলা (ভারত) | Bengali (India)</option>
+      <option value='de'>‪Deutsch | German</option>
+      <option selected value='en'>English</option>
+      <option value='es'>Español | Spanish</option>
+      <option value='fa'>‫فارسی‬ | ‪Persian</option>
+      <option value='fr'>français‬ | ‪French‬</option>
+      <option value='el'>Έλληνες | Greek</option>
+      <option value='gu-IN'>ગુજરાતી | Gujarati</option>
+      <option value='hi-IN'>हिंदी‬ | ‪Hindi‬</option>
+      <option value='id'>Indonesian</option>
+      <option value='it'>Italiano‬ | ‪Italian</option>
+      <option value='ko'>‪한국어‬ | ‪Korean‬</option>
+      <option value='lv'>Latviešu‬ | ‪Latvian</option>
+      <option value='ml-IN'>Malayalam</option>
+      <option value='ne-NP'>नेपाली | Nepali</option>
+      <option value='nl'>Dutch</option>
+      <option value='pl'>‪Polski‬ | ‪Polish‬</option>
+      <option value='pt-BR'>‪Português | Portuguese (Brasil)</option>
+      <option value='pt-PT'>‪Português‬ | Portuguese (‪Portugal)</option>
+      <option value='ro'>Română‬ | ‪Romanian</option>
+      <option value='ru-RU'>Русский‬ | ‪Russian‬</option>
+      <option value='sq'>‪shqipe‬ | ‪Albanian</option>
+      <option value='sv-SE'>Svenska‬ | ‪Swedish</option>
+      <option value='te'>తెలుగు | Telugu</option>
+      <option value='tr'>‪Türkçe‬ | ‪Turkish</option>
+      <option value='zh-CN'>中文 (中国)‬ | ‪Chinese (China)</option>
+      <option value='zh-TW'>‪中文 (台灣)‬ | ‪Chinese (Taiwan)</option>
     </select>
   </div>
 


### PR DESCRIPTION
The abbreviations used in **Language** drop-down are replaced by their respective native language names followed by a pipe and their English translation. If two languages have the same name, they are differentiated by country names.