### PR TITLE
Update the link to Instantbird developer documentation.

### DIFF
--- a/index.html
+++ b/index.html
@@ -293,7 +293,7 @@
         <li target="http://www.seamonkey-project.org/dev/" data-choice-id="seamonkey">Seamonkey
           <div class="extra" data-l10n-id="js-seamomky-extra"></div>
         </li>
-        <li target="https://wiki.instantbird.org/Main_Page" data-choice-id="instantbird">Instantbird
+        <li target="https://developer.mozilla.org/docs/Mozilla/Instantbird" data-choice-id="instantbird">Instantbird
           <div class="extra" data-l10n-id="js-instantbird-extra"></div>
         </li>
         <li target="https://wiki.mozilla.org/Webdev/GetInvolved" data-choice-id="web-development">Web development


### PR DESCRIPTION
The Instantbird wiki is currently down as we've migrated most of the information to developer.mozilla.org or wiki.mozilla.org. This updates the link for Instantbird to one that is currently active.

CC @fqueze