### PR TITLE
Remove golang option from index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -195,7 +195,6 @@
         <li next-group="perl">Perl</li>
         <li next-group="c">C</li>
         <li next-group="rust">Rust</li>
-        <li next-group="go">Go</li>
         <li next-group="swift">Swift</li>
       </ul>
     </div>


### PR DESCRIPTION
Fixes issue #326. Removing golang option from index.html because Heka was deprecated  #323 . 