### PR TITLE
Remove defunct team EngineeringProductivity

### DIFF
--- a/index.html
+++ b/index.html
@@ -347,9 +347,6 @@
         <li target="https://wiki.mozilla.org/DXR" data-choice-id="dxr">DXR
           <div class="extra" data-l10n-id="py-dxr-extra"></div>
         </li>
-        <li target="https://ateam-bootcamp.readthedocs.io/en/latest/" data-choice-id="tools">Engineering Productivity
-          <div class="extra" data-l10n-id="py-tools-extra"></div>
-        </li>
         <li target="https://wiki.mozilla.org/TestEngineering" data-choice-id="webqa-py">Firefox Test Engineering
           <div class="extra" data-l10n-id="py-webqa-extra"></div>
         </li>


### PR DESCRIPTION
This is a great resource but I noticed when following up on options to contribute that this team no longer exists.

---

According to https://wiki.mozilla.org/EngineeringProductivity
this team no longer exists.

Potentially Product Integrity or Engineering Operations could
be added in a further patch.

