### PR TITLE
Default language to English instead of crashing when browser has no language setting

### DIFF
--- a/media/js/foopy.js
+++ b/media/js/foopy.js
@@ -209,7 +209,7 @@
     }
 
     function supportsLang(value) {
-      return !! $('#lang option[value=' + value + ']').length;
+      return !! value.length && !! $('#lang option[value=' + value + ']').length;
     }
 
     function changeLang(value) {


### PR DESCRIPTION
I believe this fixes #316, which seems to happen when loading the site without any preferred language set in the browser (and without a language set in the location hash either).

Apparently, in this case webL10n was setting the language to an empty string, and then in `supportsLang` passing a selector like `#lang option[value=]` to jQuery was causing an error that basically was causing the other symptoms described in the aforementioned issue.

I just had to add a small extra check in a condition because the rest of the code in `foopy.js` already takes care of setting `en` as default —that is, if it doesn't crash.

Still, this could also had been fixed in other ways, for example by changing line 896 of `l10n.js` like this:

```js
var lang = document.documentElement.lang || navigator.language || "en";
```

but I liked the fact that `l10n.js` seems to be language-neutral in the sense that it doesn't seem to enforce any default language itself, and preferred to keep it like that.
