### PR TITLE
Removed one resource: X-Ray Goggles

### DIFF
--- a/index.html
+++ b/index.html
@@ -182,9 +182,6 @@
         <li target="https://webmaker.org/" data-choice-id="webmaker">Webmaker
           <div class="extra" data-l10n-id="webmake-extra"></div>
         </li>
-        <li target="https://goggles.webmaker.org/" data-choice-id="hackasaurus">Hackasaurus
-          <div class="extra" data-l10n-id="hackasaurus-extra" ></div>
-        </li>
       </ul>
     </div>
 


### PR DESCRIPTION
On December 16, 2019 12:00pm ET, Mozilla will be winding down X-Ray Goggles and all associated data and content will be permanently deleted. 

No need to show it there.